### PR TITLE
Remove Redux devtools from the store config

### DIFF
--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -10,12 +10,10 @@ const reducers = combineReducers({
   books,
   categories,
 });
-/* eslint-disable no-underscore-dangle */
+
 const enhancers = compose(
   applyMiddleware(thunk),
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
 );
-/* eslint-enable */
 
 const bookstoreStore = createStore(
   reducers,


### PR DESCRIPTION
#### In this PR I have removed the config for redux dev tools that was causing the app to crash when no redux devtools were installed